### PR TITLE
Changed all times to Eastern.

### DIFF
--- a/app/profile/overview/page.tsx
+++ b/app/profile/overview/page.tsx
@@ -15,7 +15,7 @@ import {Edit} from "@mui/icons-material";
 import {LOAStatus} from "@prisma/client";
 import AssignedMentorsCard from "@/components/Profile/AssignedMentorsCard";
 import ProgressionCard from "@/components/Profile/ProgressionCard";
-import {formatZuluDate, getTimeIn} from "@/lib/date";
+import {formatEasternDate, getTimeIn} from "@/lib/date";
 import CompletePreparationButton from "@/components/TrainingAppointment/CompletePreparationButton";
 import SessionJoinInstructionsButton from "@/components/TrainingAppointment/SessionJoinInstructionsButton";
 
@@ -68,7 +68,7 @@ export default async function Page() {
                         <Typography variant="h6">Training
                             Appointment: {trainingAppointment.trainer.fullName}</Typography>
                         <Typography
-                            variant="subtitle2">{formatZuluDate(trainingAppointment.start)} - {trainingAppointment.start.getTime() < (new Date()).getTime() ? 'NOW' : getTimeIn(trainingAppointment.start)}</Typography>
+                            variant="subtitle2">{formatEasternDate(trainingAppointment.start)} - {trainingAppointment.start.getTime() < (new Date()).getTime() ? 'NOW' : getTimeIn(trainingAppointment.start)}</Typography>
                         <Typography variant="subtitle2" gutterBottom>{trainingAppointment.lessons.map(l => l.duration)
                             .reduce((acc: number, curr: number) => acc + curr, 0)} minutes</Typography>
                         {trainingAppointment.lessons.map((lesson) => {

--- a/components/TrainingAppointment/TrainingAppointmentCalendar.tsx
+++ b/components/TrainingAppointment/TrainingAppointmentCalendar.tsx
@@ -28,7 +28,7 @@ export default function TrainingAppointmentCalendar({appointments, isTrainingSta
                 onClose={() => setOpenId(null)}/>}
             <FullCalendar
                 plugins={[dayGridPlugin]}
-                timeZone="UTC"
+                timeZone="local"
                 editable={false}
                 events={appointments.map((a) => ({
                     id: a.id,

--- a/components/TrainingAppointment/TrainingAppointmentFormDialog.tsx
+++ b/components/TrainingAppointment/TrainingAppointmentFormDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, {useState} from 'react';
+import timezone from "dayjs/plugin/timezone";
 import {
     Autocomplete,
     Button,
@@ -37,16 +38,17 @@ export default function TrainingAppointmentFormDialog({
 }) {
 
     dayjs.extend(utc);
+    dayjs.extend(timezone);
 
     const [open, setOpen] = useState(false);
     const [student, setStudent] = useState(trainingAppointment?.studentId || '');
-    const [start, setStart] = useState<Dayjs | null>(dayjs.utc(trainingAppointment?.start || new Date()));
+    const [start, setStart] = useState<Dayjs | null>(dayjs.utc(trainingAppointment?.start || new Date()).tz("America/New_York"));
     const [lessons, setLessons] = useState<Lesson[]>(trainingAppointment?.lessonIds.map((id) => allLessons.find((l) => l.id === id)).filter((l) => l !== undefined) as Lesson[] || []);
     const [loading, setLoading] = useState(false);
 
     const handleCreate = async () => {
         setLoading(true);
-        const {errors} = await createOrUpdateTrainingAppointment(student, start?.toISOString() || '', lessons.map((l) => l.id), trainingAppointment?.id);
+        const {errors} = await createOrUpdateTrainingAppointment(student, start?.utc().toISOString() || '', lessons.map((l) => l.id), trainingAppointment?.id);
 
         if (errors) {
             toast.error(errors.map((e) => e.message).join(', '));
@@ -58,7 +60,7 @@ export default function TrainingAppointmentFormDialog({
         setOpen(false);
         if (!trainingAppointment) {
             setStudent('');
-            setStart(dayjs.utc(new Date()));
+            setStart(dayjs.utc(new Date()).tz("America/New_York"));
             setLessons([]);
         }
         setLoading(false);
@@ -104,7 +106,7 @@ export default function TrainingAppointmentFormDialog({
                             }}
                             renderInput={(params) => <TextField {...params} required label="Student"/>}
                         />
-                        <DateTimePicker sx={{width: '100%',}} name="start" label="Start (zulu)" value={start}
+                        <DateTimePicker sx={{width: '100%',}} name="start" label="Start (Eastern Time)" value={start}
                                         disablePast ampm={false} onChange={setStart}/>
                         <Autocomplete
                             options={allLessons}

--- a/components/TrainingAppointment/TrainingAppointmentInformationDialog.tsx
+++ b/components/TrainingAppointment/TrainingAppointmentInformationDialog.tsx
@@ -5,7 +5,7 @@ import {User} from "next-auth";
 import {Visibility} from "@mui/icons-material";
 import {GridActionsCellItem} from "@mui/x-data-grid";
 import {Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from "@mui/material";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 import TrainingAppointmentDeleteButton from "@/components/TrainingAppointment/TrainingAppointmentDeleteButton";
 
 type TrainingAppointmentWithAll = TrainingAppointment & {
@@ -49,10 +49,11 @@ export default function TrainingAppointmentInformationDialog({
                     <DialogContentText>Trainer: {trainingAppointment.trainer.fullName}</DialogContentText>
                     <DialogContentText>Student: {trainingAppointment.student.fullName}</DialogContentText>
                     <br/>
-                    <DialogContentText>Start: {formatZuluDate(trainingAppointment.start)}</DialogContentText>
+                    <DialogContentText>Start (Eastern
+                        Time): {formatEasternDate(trainingAppointment.start)}</DialogContentText>
                     <DialogContentText>Duration: {trainingAppointment.lessons.map((l) => l.duration).reduce((acc, c) => acc + c, 0)} minutes</DialogContentText>
                     <DialogContentText>Estimated
-                        End: {formatZuluDate(new Date(trainingAppointment.start.getTime() + trainingAppointment.lessons.map(l => l.duration).reduce((a, b) => a + b, 0) * 60000))}</DialogContentText>
+                        End: {formatEasternDate(new Date(trainingAppointment.start.getTime() + trainingAppointment.lessons.map(l => l.duration).reduce((a, b) => a + b, 0) * 60000))}</DialogContentText>
                     <br/>
                     <DialogContentText>Preparation
                         Complete: {trainingAppointment.preparationCompleted ? 'YES' : 'NO'}</DialogContentText>

--- a/components/TrainingAppointment/TrainingAppointmentTable.tsx
+++ b/components/TrainingAppointment/TrainingAppointmentTable.tsx
@@ -4,7 +4,7 @@ import {GridColDef} from "@mui/x-data-grid";
 import Link from "next/link";
 import {Chip} from "@mui/material";
 import DataTable, {containsOnlyFilterOperator, equalsOnlyFilterOperator} from "@/components/DataTable/DataTable";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 import {Lesson, StaffPosition} from "@prisma/client";
 import {fetchTrainingAppointments} from "@/actions/trainingAppointment";
 import TrainingAppointmentDeleteButton from "@/components/TrainingAppointment/TrainingAppointmentDeleteButton";
@@ -53,8 +53,8 @@ export default function TrainingAppointmentTable({sessionUser}: { sessionUser: U
         {
             field: 'start',
             flex: 1,
-            headerName: 'Start (Zulu)',
-            renderCell: (params) => formatZuluDate(params.row.start),
+            headerName: 'Start (Eastern Time)',
+            renderCell: (params) => formatEasternDate(params.row.start),
             type: 'dateTime',
             filterable: false,
         },

--- a/components/TrainingAssignment/TrainingAssignmentTable.tsx
+++ b/components/TrainingAssignment/TrainingAssignmentTable.tsx
@@ -11,7 +11,7 @@ import {useRouter} from "next/navigation";
 import {getRating} from "@/lib/vatsim";
 import Link from "next/link";
 import {Lesson} from "@prisma/client";
-import {formatZuluDate, getTimeAgo, getTimeIn} from "@/lib/date";
+import {formatEasternDate, formatZuluDate, getTimeAgo, getTimeIn} from "@/lib/date";
 
 export default function TrainingAssignmentTable({manageMode}: { manageMode: boolean }) {
 
@@ -126,7 +126,7 @@ export default function TrainingAssignmentTable({manageMode}: { manageMode: bool
 
                 return (
                     <Tooltip
-                        title={`${formatZuluDate(startDate)} with ${appointment.trainer.fullName}: ${appointment.lessons.map((l: Lesson) => l.identifier).join(', ')}`}>
+                        title={`${formatEasternDate(startDate)} with ${appointment.trainer.fullName}: ${appointment.lessons.map((l: Lesson) => l.identifier).join(', ')}`}>
                         <Link
                             href={`/training/appointments?sortField=start&sortDirection=asc&filterField=student&filterValue=${params.row.student.cid}&filterOperator=equals`}>
                             <Chip

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,3 +1,11 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 export const getDaysLeft = (date: Date): string => {
     const now = new Date();
     const diff = date.getTime() - now.getTime();
@@ -85,3 +93,7 @@ export const eventGetDuration = (start: Date, end: Date, days?: boolean) => {
     }
     return hours + minutes / 60;
 }
+
+export const formatEasternDate = (date: Date) => {
+    return dayjs.utc(date).tz("America/New_York").format("MM/DD/YY HH:mm");
+};

--- a/templates/TrainingAppointment/AppointmentCanceled.tsx
+++ b/templates/TrainingAppointment/AppointmentCanceled.tsx
@@ -2,14 +2,14 @@ import {TrainingAppointment} from "@prisma/client";
 import React from "react";
 import SingleRecipientEmailWrapper from "@/templates/Wrapper/SingleRecipientEmailWrapper";
 import {renderReactToMjml} from "@/actions/mjml";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 import {getRating} from "@/lib/vatsim";
 import {User} from "next-auth";
 
 export const appointmentCanceled = async (trainingAppointment: TrainingAppointment, student: User, trainer: User) => {
     return renderReactToMjml(
         <SingleRecipientEmailWrapper recipient={student} headerText="Training Appointment Canceled">
-            <p>Your training appointment on <b>{formatZuluDate(trainingAppointment.start)}</b> has been canceled.</p>
+            <p>Your training appointment on <b>{formatEasternDate(trainingAppointment.start)}</b> has been canceled.</p>
             <p>You are no longer required to attend this appointment.</p>
             <br/>
             <p>Contact your trainer if you have any questions.</p>

--- a/templates/TrainingAppointment/AppointmentCanceledTrainer.tsx
+++ b/templates/TrainingAppointment/AppointmentCanceledTrainer.tsx
@@ -2,13 +2,14 @@ import {TrainingAppointment} from "@prisma/client";
 import {User} from "next-auth";
 import {renderReactToMjml} from "@/actions/mjml";
 import SingleRecipientEmailWrapper from "@/templates/Wrapper/SingleRecipientEmailWrapper";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 
 export const appointmentCanceledTrainer = async (trainingAppointment: TrainingAppointment, student: User, trainer: User) => {
     return renderReactToMjml(
         <SingleRecipientEmailWrapper recipient={trainer} headerText="Training Appointment Canceled">
             <p>Your training appointment
-                with <b>{student.fullName}</b> on <b>{formatZuluDate(trainingAppointment.start)}</b> has been cancelled
+                with <b>{student.fullName}</b> on <b>{formatEasternDate(trainingAppointment.start)}</b> has been
+                cancelled
                 by staff.</p>
             <p>You are no longer required to attend this appointment.</p>
             <br/>

--- a/templates/TrainingAppointment/AppointmentScheduled.tsx
+++ b/templates/TrainingAppointment/AppointmentScheduled.tsx
@@ -2,13 +2,14 @@ import {TrainingAppointment} from "@prisma/client";
 import {User} from "next-auth";
 import {renderReactToMjml} from "@/actions/mjml";
 import SingleRecipientEmailWrapper from "@/templates/Wrapper/SingleRecipientEmailWrapper";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 import {getRating} from "@/lib/vatsim";
 
 export const appointmentScheduled = async (trainingAppointment: TrainingAppointment, student: User, trainer: User) => {
     return renderReactToMjml(
         <SingleRecipientEmailWrapper recipient={student} headerText="Training Appointment Scheduled">
-            <p>A training appointment has been scheduled for you on <b>{formatZuluDate(trainingAppointment.start)}</b>.
+            <p>A training appointment has been scheduled for you
+                on <b>{formatEasternDate(trainingAppointment.start)}</b>.
             </p>
             <p>The estimated duration for this appointment can be found on your profile.</p>
             <br/>

--- a/templates/TrainingAppointment/AppointmentUpdated.tsx
+++ b/templates/TrainingAppointment/AppointmentUpdated.tsx
@@ -2,13 +2,13 @@ import {renderReactToMjml} from "@/actions/mjml";
 import SingleRecipientEmailWrapper from "@/templates/Wrapper/SingleRecipientEmailWrapper";
 import {TrainingAppointment} from "@prisma/client";
 import {User} from "next-auth";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 import {getRating} from "@/lib/vatsim";
 
 export const appointmentUpdated = async (trainingAppointment: TrainingAppointment, student: User, trainer: User) => {
     return renderReactToMjml(
         <SingleRecipientEmailWrapper recipient={student} headerText="Training Appointment Updated">
-            <p>Your training appointment on <b>{formatZuluDate(trainingAppointment.start)}</b> has been updated.</p>
+            <p>Your training appointment on <b>{formatEasternDate(trainingAppointment.start)}</b> has been updated.</p>
             <p>Make sure you are familiar with the updates prior to the start time.</p>
             <br/>
             <p>Please check <a href="https://vzdc.org/profile/overview">your profile</a> for more details.</p>

--- a/templates/TrainingAppointment/AppointmentWarning.tsx
+++ b/templates/TrainingAppointment/AppointmentWarning.tsx
@@ -1,7 +1,7 @@
 import {TrainingAppointment} from "@prisma/client";
 import {renderReactToMjml} from "@/actions/mjml";
 import SingleRecipientEmailWrapper from "@/templates/Wrapper/SingleRecipientEmailWrapper";
-import {formatZuluDate} from "@/lib/date";
+import {formatEasternDate} from "@/lib/date";
 import {getRating} from "@/lib/vatsim";
 import {User} from "next-auth";
 
@@ -9,7 +9,7 @@ export const appointmentWarning = async (trainingAppointment: TrainingAppointmen
     return renderReactToMjml(
         <SingleRecipientEmailWrapper recipient={student} headerText="Training Appointment Soon">
             <p>This is a reminder about your training appointment scheduled
-                on <b>{formatZuluDate(trainingAppointment.start)}</b>.</p>
+                on <b>{formatEasternDate(trainingAppointment.start)}</b>.</p>
             <p>You are required to attend this appointment unless you contact your trainer prior to the start time.</p>
             <br/>
             {!trainingAppointment.preparationCompleted && <>


### PR DESCRIPTION
This pull request introduces a shift from Zulu (UTC) time to Eastern Time (ET) across various parts of the application, ensuring consistency in how dates and times are displayed to users. It also adds functionality to create calendar links for training appointments and updates timezone handling for better accuracy. Below is a breakdown of the most significant changes:

### Timezone and Date Formatting Updates:
* Introduced a new utility function `formatEasternDate` in `lib/date.ts` to format dates in Eastern Time (`MM/DD/YY HH:mm`). This replaces the previous `formatZuluDate` in multiple components, including `TrainingAppointmentCalendar`, `TrainingAppointmentInformationDialog`, and `TrainingAppointmentTable`. [[1]](diffhunk://#diff-0235c12bd36d9dcdfc03ce0993ffc6fbf4057dec2e537e7b93b2fed4f3dfeef6R1-R8) [[2]](diffhunk://#diff-0235c12bd36d9dcdfc03ce0993ffc6fbf4057dec2e537e7b93b2fed4f3dfeef6R96-R99) [[3]](diffhunk://#diff-bbf99bff175f44e98cd79693d89aa04a919c1d05a24aed372ecc56dd389478a4L18-R18) [[4]](diffhunk://#diff-7cb8766657e6b15744027e6fbd63bf71f85af38f23a7c8cd456c02d365564b2eL248-R272) [[5]](diffhunk://#diff-039115962d2aafee0c3c3c9d1a9b1920e8285f14f5b0addea0157671dd7cb632L56-R57) [[6]](diffhunk://#diff-1cf92c5c1eb22c51ccc33331c45828792442d721365ea7a94de63160999d59e7L52-R56)

* Updated the `DateTimePicker` in `TrainingAppointmentFormDialog` to use Eastern Time by default and adjusted the `start` field to convert to UTC before submission. [[1]](diffhunk://#diff-f18a3833b4620cd01386438af77bf53904a7785f684f9a76ed3ab3775f3478e3R41-R51) [[2]](diffhunk://#diff-f18a3833b4620cd01386438af77bf53904a7785f684f9a76ed3ab3775f3478e3L61-R63) [[3]](diffhunk://#diff-f18a3833b4620cd01386438af77bf53904a7785f684f9a76ed3ab3775f3478e3L107-R109)

### Calendar Link Generation:
* Added a `createCalendarLink` function in `app/training/your-students/page.tsx` to generate Google Calendar links for training appointments. These links include session details, start/end times, and timezone information. [[1]](diffhunk://#diff-7cb8766657e6b15744027e6fbd63bf71f85af38f23a7c8cd456c02d365564b2eL22-R50) [[2]](diffhunk://#diff-7cb8766657e6b15744027e6fbd63bf71f85af38f23a7c8cd456c02d365564b2eR288-R302)

### Email Notification Updates:
* Updated email templates (`AppointmentCanceled`, `AppointmentCanceledTrainer`, `AppointmentScheduled`, `AppointmentUpdated`) to display appointment times in Eastern Time instead of Zulu. [[1]](diffhunk://#diff-a4f9dd906871be1a6ee3a5eefe93660025f842d14941d8514546420c2c4ce09cL5-R12) [[2]](diffhunk://#diff-29c6b6cec4720e6b8d45849ce865230007a85e0db4bd94be7a285e49155e2f34L5-R12) [[3]](diffhunk://#diff-0e68514b94288e9d87c848930319c510bd17ee8f7c3a6079cc2751fd2d8041aeL5-R12) [[4]](diffhunk://#diff-6efa5026cf100eac339f64beed7c0785528ababea8621026f1117f3aac38ea49L5-R11)

### Timezone Handling Enhancements:
* Extended `dayjs` with `utc` and `timezone` plugins for consistent timezone conversions. Updated `TrainingAppointmentFormDialog` and `TrainingAppointmentCalendar` to use local or Eastern Time as appropriate. [[1]](diffhunk://#diff-0235c12bd36d9dcdfc03ce0993ffc6fbf4057dec2e537e7b93b2fed4f3dfeef6R1-R8) [[2]](diffhunk://#diff-f18a3833b4620cd01386438af77bf53904a7785f684f9a76ed3ab3775f3478e3R3) [[3]](diffhunk://#diff-f4ee17b5b62c018e6f94196a5b4d50af2d0d9f6a24e41670fd8c38ee655cbc1fL31-R31)

These changes improve user experience by aligning displayed times with the Eastern Time zone, enhancing scheduling functionality, and ensuring consistency across the application.